### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+ethdo
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+coverage.html
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/
+
+# Vim
+*.sw?
+
+# Local TODO
+TODO.md
+
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM golang:1.14.2-alpine3.11 as builder
-
-RUN apk add build-base
+FROM golang:1.14-buster as builder
 
 WORKDIR /app
 
@@ -12,9 +10,7 @@ COPY . .
 
 RUN go build
 
-FROM alpine:3.11
-
-RUN apk add libstdc++
+FROM debian:buster-slim
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.14.2-alpine3.11 as builder
+
+RUN apk add build-base
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+RUN go build
+
+FROM alpine:3.11
+
+RUN apk add libstdc++
+
+WORKDIR /app
+
+COPY --from=builder /app/ethdo /app
+
+ENTRYPOINT ["/app/ethdo"]

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A command-line tool for managing common tasks in Ethereum 2.
 
 ## Table of Contents
 
-- [Install](#install)
-- [Usage](#usage)
-- [Maintainers](#maintainers)
-- [Contribute](#contribute)
-- [License](#license)
+- [Commands](#commands)
+- [HOWTO](#howto)
+  - [Maintainers](#maintainers)
+  - [Contribute](#contribute)
+  - [License](#license)
 
 ## Install
 
@@ -26,6 +26,20 @@ GO111MODULE=on go get github.com/wealdtech/ethdo
 Note that `ethdo` requires at least version 1.13 of go to operate.  The version of go can be found with `go version`.
 
 If this does not work please see the [troubleshooting](https://github.com/wealdtech/ethdo/blob/master/docs/troubleshooting.md) page.
+
+## Docker
+
+It is possible to build the tool using docker:
+
+```sh
+docker build -t ethdo .
+```
+
+You can run the tool using docker after that. Example:
+
+```sh
+docker run -it ethdo --help
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ A command-line tool for managing common tasks in Ethereum 2.
 
 ## Table of Contents
 
-- [Commands](#commands)
-- [HOWTO](#howto)
-  - [Maintainers](#maintainers)
-  - [Contribute](#contribute)
-  - [License](#license)
+- [Install](#install)
+  - [Docker](#docker)
+- [Usage](#usage)
+- [Maintainers](#maintainers)
+- [Contribute](#contribute)
+- [License](#license)
 
 ## Install
 
@@ -27,7 +28,7 @@ Note that `ethdo` requires at least version 1.13 of go to operate.  The version 
 
 If this does not work please see the [troubleshooting](https://github.com/wealdtech/ethdo/blob/master/docs/troubleshooting.md) page.
 
-## Docker
+### Docker
 
 It is possible to build the tool using docker:
 


### PR DESCRIPTION
Add a Dockerfile, which allows to build and use the tool using docker. The image size is ~40MB and can be tested from my local docker hub image:

```sh
docker run -it valo/ethdo --help
```