### PR TITLE
Update launchpad output to be an array

### DIFF
--- a/cmd/validatordepositdata.go
+++ b/cmd/validatordepositdata.go
@@ -192,7 +192,7 @@ In quiet mode this will return 0 if the the data can be generated correctly, oth
 				}
 				depositMessageRoot, err := ssz.HashTreeRoot(depositMessage)
 				errCheck(err, "Failed to generate deposit message root")
-				outputs = append(outputs, fmt.Sprintf(`{"pubkey":"%x","withdrawal_credentials":"%x","amount":%d,"signature":"%x","deposit_message_root":"%x","deposit_data_root":"%x","fork_version":"%x"}`, signedDepositData.PubKey, signedDepositData.WithdrawalCredentials, val, signedDepositData.Signature, depositMessageRoot, depositDataRoot, forkVersion))
+				outputs = append(outputs, fmt.Sprintf(`[{"pubkey":"%x","withdrawal_credentials":"%x","amount":%d,"signature":"%x","deposit_message_root":"%x","deposit_data_root":"%x","fork_version":"%x"}]`, signedDepositData.PubKey, signedDepositData.WithdrawalCredentials, val, signedDepositData.Signature, depositMessageRoot, depositDataRoot, forkVersion))
 			default:
 				outputs = append(outputs, fmt.Sprintf(`{"name":"Deposit for %s","account":"%s","pubkey":"%#x","withdrawal_credentials":"%#x","signature":"%#x","value":%d,"deposit_data_root":"%#x","version":2}`, fmt.Sprintf("%s/%s", validatorWallet.Name(), validatorAccount.Name()), fmt.Sprintf("%s/%s", validatorWallet.Name(), validatorAccount.Name()), signedDepositData.PubKey, signedDepositData.WithdrawalCredentials, signedDepositData.Signature, val, depositDataRoot))
 			}


### PR DESCRIPTION
The launchpad requires that the deposit data be nested in an array. So if you pipe the output to a file, the launchpad still says it's invalid, until you add `[ ]` to the output.

This will output as an array so it can be copied or piped to a file without any manual changes.

I can also see why you might not want to do this, so I'll leave it up to you if you want to merge or cancel this.