### PR TITLE
Allow use of Ethereum 1 withdrawal credentials

### DIFF
--- a/cmd/validator/depositdata/input_internal_test.go
+++ b/cmd/validator/depositdata/input_internal_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019, 2020 Weald Technology Trading
+// Copyright © 2019-2021 Weald Technology Trading
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -85,8 +85,19 @@ func TestInput(t *testing.T) {
 			err:  "validator account is required",
 		},
 		{
+			name: "TimeoutMissing",
+			vars: map[string]interface{}{
+				"validatoraccount":  "Test/Interop 0",
+				"withdrawalaccount": "Test/Interop 0",
+				"depositvalue":      "32 Ether",
+				"forkversion":       "0x01020304",
+			},
+			err: "timeout is required",
+		},
+		{
 			name: "ValidatorAccountMissing",
 			vars: map[string]interface{}{
+				"timeout":           "10s",
 				"withdrawalaccount": "Test/Interop 0",
 				"depositvalue":      "32 Ether",
 				"forkversion":       "0x01020304",
@@ -96,6 +107,7 @@ func TestInput(t *testing.T) {
 		{
 			name: "ValidatorAccountUnknown",
 			vars: map[string]interface{}{
+				"timeout":           "10s",
 				"validatoraccount":  "Test/Unknown",
 				"withdrawalaccount": "Test/Interop 0",
 				"depositvalue":      "32 Ether",
@@ -104,59 +116,74 @@ func TestInput(t *testing.T) {
 			err: "unknown validator account",
 		},
 		{
-			name: "WithdrawalAccountMissing",
+			name: "WithdrawalDetailsMissing",
 			vars: map[string]interface{}{
+				"timeout":          "10s",
 				"launchpad":        true,
 				"validatoraccount": "Test/Interop 0",
 				"depositvalue":     "32 Ether",
 				"forkversion":      "0x01020304",
 			},
-			err: "withdrawalaccount or withdrawal public key is required",
+			err: "withdrawal account, public key or address is required",
 		},
 		{
-			name: "WithdrawalAccountUnknown",
+			name: "WithdrawalDetailsTooMany1",
 			vars: map[string]interface{}{
-				"raw":               true,
+				"timeout":           "10s",
+				"launchpad":         true,
 				"validatoraccount":  "Test/Interop 0",
-				"withdrawalaccount": "Test/Unknown",
+				"withdrawalaccount": "Test/Interop 0",
+				"withdrawalpubkey":  "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
 				"depositvalue":      "32 Ether",
 				"forkversion":       "0x01020304",
 			},
-			err: "failed to obtain withdrawal account: failed to obtain account: no account with name \"Unknown\"",
+			err: "only one of withdrawal account, public key or address is allowed",
 		},
 		{
-			name: "WithdrawalPubKeyInvalid",
+			name: "WithdrawalDetailsTooMany2",
 			vars: map[string]interface{}{
-				"validatoraccount": "Test/Interop 0",
-				"withdrawalpubkey": "invalid",
-				"depositvalue":     "32 Ether",
-				"forkversion":      "0x01020304",
+				"timeout":           "10s",
+				"launchpad":         true,
+				"validatoraccount":  "Test/Interop 0",
+				"withdrawalaccount": "Test/Interop 0",
+				"withdrawalpubkey":  "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+				"withdrawaladdress": "0x30C99930617B7b793beaB603ecEB08691005f2E5",
+				"depositvalue":      "32 Ether",
+				"forkversion":       "0x01020304",
 			},
-			err: "failed to decode withdrawal public key: encoding/hex: invalid byte: U+0069 'i'",
+			err: "only one of withdrawal account, public key or address is allowed",
 		},
 		{
-			name: "WithdrawalPubKeyWrongLength",
+			name: "WithdrawalDetailsTooMany3",
 			vars: map[string]interface{}{
-				"validatoraccount": "Test/Interop 0",
-				"withdrawalpubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0bff",
-				"depositvalue":     "32 Ether",
-				"forkversion":      "0x01020304",
+				"timeout":           "10s",
+				"launchpad":         true,
+				"validatoraccount":  "Test/Interop 0",
+				"withdrawalpubkey":  "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+				"withdrawaladdress": "0x30C99930617B7b793beaB603ecEB08691005f2E5",
+				"depositvalue":      "32 Ether",
+				"forkversion":       "0x01020304",
 			},
-			err: "withdrawal public key must be exactly 48 bytes in length",
+			err: "only one of withdrawal account, public key or address is allowed",
 		},
 		{
-			name: "WithdrawalPubKeyNotPubKey",
+			name: "WithdrawalDetailsTooMany4",
 			vars: map[string]interface{}{
-				"validatoraccount": "Test/Interop 0",
-				"withdrawalpubkey": "0x089bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
-				"depositvalue":     "32 Ether",
-				"forkversion":      "0x01020304",
+				"timeout":           "10s",
+				"launchpad":         true,
+				"validatoraccount":  "Test/Interop 0",
+				"withdrawalaccount": "Test/Interop 0",
+				"withdrawalpubkey":  "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+				"withdrawaladdress": "0x30C99930617B7b793beaB603ecEB08691005f2E5",
+				"depositvalue":      "32 Ether",
+				"forkversion":       "0x01020304",
 			},
-			err: "withdrawal public key is not valid: failed to deserialize public key: err blsPublicKeyDeserialize 089bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+			err: "only one of withdrawal account, public key or address is allowed",
 		},
 		{
 			name: "DepositValueMissing",
 			vars: map[string]interface{}{
+				"timeout":           "10s",
 				"validatoraccount":  "Test/Interop 0",
 				"withdrawalaccount": "Test/Interop 0",
 				"forkversion":       "0x01020304",
@@ -166,6 +193,7 @@ func TestInput(t *testing.T) {
 		{
 			name: "DepositValueTooSmall",
 			vars: map[string]interface{}{
+				"timeout":           "10s",
 				"validatoraccount":  "Test/Interop 0",
 				"withdrawalaccount": "Test/Interop 0",
 				"depositvalue":      "1000 Wei",
@@ -176,6 +204,7 @@ func TestInput(t *testing.T) {
 		{
 			name: "DepositValueInvalid",
 			vars: map[string]interface{}{
+				"timeout":           "10s",
 				"validatoraccount":  "Test/Interop 0",
 				"withdrawalaccount": "Test/Interop 0",
 				"depositvalue":      "1 groat",
@@ -186,6 +215,7 @@ func TestInput(t *testing.T) {
 		{
 			name: "ForkVersionInvalid",
 			vars: map[string]interface{}{
+				"timeout":           "10s",
 				"validatoraccount":  "Test/Interop 0",
 				"withdrawalaccount": "Test/Interop 0",
 				"depositvalue":      "32 Ether",
@@ -194,53 +224,67 @@ func TestInput(t *testing.T) {
 			err: "failed to obtain fork version: failed to decode fork version: encoding/hex: invalid byte: U+0069 'i'",
 		},
 		{
+			name: "ForkVersionShort",
+			vars: map[string]interface{}{
+				"timeout":           "10s",
+				"validatoraccount":  "Test/Interop 0",
+				"withdrawalaccount": "Test/Interop 0",
+				"depositvalue":      "32 Ether",
+				"forkversion":       "0x01",
+			},
+			err: "failed to obtain fork version: fork version must be exactly 4 bytes in length",
+		},
+		{
 			name: "Good",
 			vars: map[string]interface{}{
+				"timeout":           "10s",
 				"validatoraccount":  "Test/Interop 0",
 				"withdrawalaccount": "Test/Interop 0",
 				"depositvalue":      "32 Ether",
 			},
 			res: &dataIn{
-				format:                "json",
-				withdrawalCredentials: testutil.HexToBytes("0x00fad2a6bfb0e7f1f0f45460944fbd8dfa7f37da06a4d13b3983cc90bb46963b"),
-				amount:                32000000000,
-				validatorAccounts:     []e2wtypes.Account{interop0},
-				forkVersion:           mainnetForkVersion,
-				domain:                mainnetDomain,
+				format:            "json",
+				withdrawalAccount: "Test/Interop 0",
+				amount:            32000000000,
+				validatorAccounts: []e2wtypes.Account{interop0},
+				forkVersion:       mainnetForkVersion,
+				domain:            mainnetDomain,
 			},
 		},
 		{
 			name: "GoodForkVersionOverride",
 			vars: map[string]interface{}{
+				"timeout":           "10s",
 				"validatoraccount":  "Test/Interop 0",
 				"withdrawalaccount": "Test/Interop 0",
 				"depositvalue":      "32 Ether",
 				"forkversion":       "0x01020304",
 			},
 			res: &dataIn{
-				format:                "json",
-				withdrawalCredentials: testutil.HexToBytes("0x00fad2a6bfb0e7f1f0f45460944fbd8dfa7f37da06a4d13b3983cc90bb46963b"),
-				amount:                32000000000,
-				validatorAccounts:     []e2wtypes.Account{interop0},
-				forkVersion:           forkVersion,
-				domain:                domain,
+				format:            "json",
+				withdrawalAccount: "Test/Interop 0",
+				amount:            32000000000,
+				validatorAccounts: []e2wtypes.Account{interop0},
+				forkVersion:       forkVersion,
+				domain:            domain,
 			},
 		},
 		{
 			name: "GoodWithdrawalPubKey",
 			vars: map[string]interface{}{
+				"timeout":          "10s",
 				"validatoraccount": "Test/Interop 0",
 				"withdrawalpubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
 				"depositvalue":     "32 Ether",
 				"forkversion":      "0x01020304",
 			},
 			res: &dataIn{
-				format:                "json",
-				withdrawalCredentials: testutil.HexToBytes("0x00fad2a6bfb0e7f1f0f45460944fbd8dfa7f37da06a4d13b3983cc90bb46963b"),
-				amount:                32000000000,
-				validatorAccounts:     []e2wtypes.Account{interop0},
-				forkVersion:           forkVersion,
-				domain:                domain,
+				format:            "json",
+				withdrawalPubKey:  "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+				amount:            32000000000,
+				validatorAccounts: []e2wtypes.Account{interop0},
+				forkVersion:       forkVersion,
+				domain:            domain,
 			},
 		},
 	}
@@ -258,7 +302,9 @@ func TestInput(t *testing.T) {
 				require.NoError(t, err)
 				// Cannot compare accounts directly, so need to check each element individually.
 				require.Equal(t, test.res.format, res.format)
-				require.Equal(t, test.res.withdrawalCredentials, res.withdrawalCredentials)
+				require.Equal(t, test.res.withdrawalAccount, res.withdrawalAccount)
+				require.Equal(t, test.res.withdrawalAddress, res.withdrawalAddress)
+				require.Equal(t, test.res.withdrawalPubKey, res.withdrawalPubKey)
 				require.Equal(t, test.res.amount, res.amount)
 				require.Equal(t, test.res.forkVersion, res.forkVersion)
 				require.Equal(t, test.res.domain, res.domain)

--- a/cmd/validator/depositdata/process.go
+++ b/cmd/validator/depositdata/process.go
@@ -1,4 +1,4 @@
-// Copyright © 2019, 2020 Weald Technology Trading
+// Copyright © 2019-2021 Weald Technology Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,12 +15,16 @@ package depositdata
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
+	"strings"
 
 	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/pkg/errors"
 	"github.com/wealdtech/ethdo/signing"
-	"github.com/wealdtech/ethdo/util"
+	ethdoutil "github.com/wealdtech/ethdo/util"
+	e2types "github.com/wealdtech/go-eth2-types/v2"
+	util "github.com/wealdtech/go-eth2-util"
 	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
 )
 
@@ -31,8 +35,13 @@ func process(data *dataIn) ([]*dataOut, error) {
 
 	results := make([]*dataOut, 0)
 
+	withdrawalCredentials, err := createWithdrawalCredentials(data)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, validatorAccount := range data.validatorAccounts {
-		validatorPubKey, err := util.BestPublicKey(validatorAccount)
+		validatorPubKey, err := ethdoutil.BestPublicKey(validatorAccount)
 		if err != nil {
 			return nil, errors.Wrap(err, "validator account does not provide a public key")
 		}
@@ -41,7 +50,7 @@ func process(data *dataIn) ([]*dataOut, error) {
 		copy(pubKey[:], validatorPubKey.Marshal())
 		depositMessage := &spec.DepositMessage{
 			PublicKey:             pubKey,
-			WithdrawalCredentials: data.withdrawalCredentials,
+			WithdrawalCredentials: withdrawalCredentials,
 			Amount:                data.amount,
 		}
 		root, err := depositMessage.HashTreeRoot()
@@ -58,7 +67,7 @@ func process(data *dataIn) ([]*dataOut, error) {
 
 		depositData := &spec.DepositData{
 			PublicKey:             pubKey,
-			WithdrawalCredentials: data.withdrawalCredentials,
+			WithdrawalCredentials: withdrawalCredentials,
 			Amount:                data.amount,
 			Signature:             sig,
 		}
@@ -75,7 +84,7 @@ func process(data *dataIn) ([]*dataOut, error) {
 			format:                data.format,
 			account:               fmt.Sprintf("%s/%s", validatorWallet.Name(), validatorAccount.Name()),
 			validatorPubKey:       &pubKey,
-			withdrawalCredentials: data.withdrawalCredentials,
+			withdrawalCredentials: withdrawalCredentials,
 			amount:                data.amount,
 			signature:             &sig,
 			forkVersion:           data.forkVersion,
@@ -84,4 +93,81 @@ func process(data *dataIn) ([]*dataOut, error) {
 		})
 	}
 	return results, nil
+}
+
+// createWithdrawalCredentials creates withdrawal credentials given an account, public key or Ethereum 1 address.
+func createWithdrawalCredentials(data *dataIn) ([]byte, error) {
+	var withdrawalCredentials []byte
+
+	switch {
+	case data.withdrawalAccount != "":
+		ctx, cancel := context.WithTimeout(context.Background(), data.timeout)
+		defer cancel()
+		_, withdrawalAccount, err := ethdoutil.WalletAndAccountFromPath(ctx, data.withdrawalAccount)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to obtain withdrawal account")
+		}
+		pubKey, err := ethdoutil.BestPublicKey(withdrawalAccount)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to obtain public key for withdrawal account")
+		}
+		withdrawalCredentials = util.SHA256(pubKey.Marshal())
+		// This is hard-coded, to allow deposit data to be generated without a connection to the beacon node.
+		withdrawalCredentials[0] = byte(0) // BLS_WITHDRAWAL_PREFIX
+	case data.withdrawalPubKey != "":
+		withdrawalPubKeyBytes, err := hex.DecodeString(strings.TrimPrefix(data.withdrawalPubKey, "0x"))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to decode withdrawal public key")
+		}
+		if len(withdrawalPubKeyBytes) != 48 {
+			return nil, errors.New("withdrawal public key must be exactly 48 bytes in length")
+		}
+		pubKey, err := e2types.BLSPublicKeyFromBytes(withdrawalPubKeyBytes)
+		if err != nil {
+			return nil, errors.Wrap(err, "withdrawal public key is not valid")
+		}
+		withdrawalCredentials = util.SHA256(pubKey.Marshal())
+		// This is hard-coded, to allow deposit data to be generated without a connection to the beacon node.
+		withdrawalCredentials[0] = byte(0) // BLS_WITHDRAWAL_PREFIX
+	case data.withdrawalAddress != "":
+		withdrawalAddressBytes, err := hex.DecodeString(strings.TrimPrefix(data.withdrawalAddress, "0x"))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to decode withdrawal address")
+		}
+		if len(withdrawalAddressBytes) != 20 {
+			return nil, errors.New("withdrawal address must be exactly 20 bytes in length")
+		}
+		// Ensure the address is properly checksummed.
+		checksummedAddress := addressBytesToEIP55(withdrawalAddressBytes)
+		if checksummedAddress != data.withdrawalAddress {
+			return nil, fmt.Errorf("withdrawal address checksum does not match (expected %s)", checksummedAddress)
+		}
+		withdrawalCredentials = make([]byte, 32)
+		copy(withdrawalCredentials[12:32], withdrawalAddressBytes)
+		// This is hard-coded, to allow deposit data to be generated without a connection to the beacon node.
+		withdrawalCredentials[0] = byte(1) // ETH1_ADDRESS_WITHDRAWAL_PREFIX
+	default:
+		return nil, errors.New("withdrawal account, public key or address is required")
+	}
+
+	return withdrawalCredentials, nil
+}
+
+// addressBytesToEIP55 converts a byte array in to an EIP-55 string format.
+func addressBytesToEIP55(address []byte) string {
+	bytes := []byte(fmt.Sprintf("%x", address))
+	hash := util.Keccak256(bytes)
+	for i := 0; i < len(bytes); i++ {
+		hashByte := hash[i/2]
+		if i%2 == 0 {
+			hashByte >>= 4
+		} else {
+			hashByte &= 0xf
+		}
+		if bytes[i] > '9' && hashByte > 7 {
+			bytes[i] -= 32
+		}
+	}
+
+	return fmt.Sprintf("0x%s", string(bytes))
 }

--- a/cmd/validatordepositdata.go
+++ b/cmd/validatordepositdata.go
@@ -49,9 +49,10 @@ In quiet mode this will return 0 if the the data can be generated correctly, oth
 func init() {
 	validatorCmd.AddCommand(validatorDepositDataCmd)
 	validatorFlags(validatorDepositDataCmd)
-	validatorDepositDataCmd.Flags().String("validatoraccount", "", "Account of the account carrying out the validation")
-	validatorDepositDataCmd.Flags().String("withdrawalaccount", "", "Account of the account to which the validator funds will be withdrawn")
+	validatorDepositDataCmd.Flags().String("validatoraccount", "", "Account carrying out the validation")
+	validatorDepositDataCmd.Flags().String("withdrawalaccount", "", "Account to which the validator funds will be withdrawn")
 	validatorDepositDataCmd.Flags().String("withdrawalpubkey", "", "Public key of the account to which the validator funds will be withdrawn")
+	validatorDepositDataCmd.Flags().String("withdrawaladdress", "", "Ethereum 1 address of the account to which the validator funds will be withdrawn")
 	validatorDepositDataCmd.Flags().String("depositvalue", "", "Value of the amount to be deposited")
 	validatorDepositDataCmd.Flags().Bool("raw", false, "Print raw deposit data transaction data")
 	validatorDepositDataCmd.Flags().String("forkversion", "", "Use a hard-coded fork version (default is to fetch it from the node)")
@@ -66,6 +67,9 @@ func validatorDepositdataBindings() {
 		panic(err)
 	}
 	if err := viper.BindPFlag("withdrawalpubkey", validatorDepositDataCmd.Flags().Lookup("withdrawalpubkey")); err != nil {
+		panic(err)
+	}
+	if err := viper.BindPFlag("withdrawaladdress", validatorDepositDataCmd.Flags().Lookup("withdrawaladdress")); err != nil {
 		panic(err)
 	}
 	if err := viper.BindPFlag("depositvalue", validatorDepositDataCmd.Flags().Lookup("depositvalue")); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/wealdtech/go-eth2-wallet-store-scratch v1.6.2
 	github.com/wealdtech/go-eth2-wallet-types/v2 v2.8.2
 	github.com/wealdtech/go-string2eth v1.1.0
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
 	golang.org/x/text v0.3.5
 	google.golang.org/genproto v0.0.0-20210201184850-646a494a81ea // indirect


### PR DESCRIPTION
Release 1.0.1 of the Ethereum 2 specification allows withdrawal credentials to be Ethereum 1 addresses.  This enables the use of such addresses when generating and verifying deposit data.