### PR TITLE
Correct domain type for exits

### DIFF
--- a/cmd/validator/exit/process.go
+++ b/cmd/validator/exit/process.go
@@ -472,7 +472,7 @@ func (c *command) generateDomain(ctx context.Context) error {
 		return errors.Wrap(err, "failed to calculate signature domain")
 	}
 
-	copy(c.domain[:], c.chainInfo.BLSToExecutionChangeDomainType[:])
+	copy(c.domain[:], c.chainInfo.VoluntaryExitDomainType[:])
 	copy(c.domain[4:], root[:])
 	if c.debug {
 		fmt.Fprintf(os.Stderr, "Domain is %#x\n", c.domain)


### PR DESCRIPTION
Previously the exit command was using the wrong domain type for signatures. This PR fixes this.