### PR TITLE
typo-Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If using the filesystem store, the additional parameter `base-dir` can be suppli
 >
 > This will allow you to use `ethdo` with or without docker, with the same location for wallets and accounts.
 
-All ethdo comands take the following parameters:
+All ethdo commands take the following parameters:
 
   - `store`: the name of the storage system for wallets.  This can be one of "filesystem" (for local storage of the wallet) or "s3" (for remote storage of the wallet on [Amazon's S3](https://aws.amazon.com/s3/) storage system), and defaults to "filesystem"
   - `storepassphrase`: the passphrase for the store.  If this is empty the store is unencrypted


### PR DESCRIPTION
# Fix: Corrected typo in README file

## Changes
1. **File**: `README.md`
   - Fixed a typo by changing "comands" to "commands" (Line 116).

## Purpose
- Improved documentation accuracy by fixing the typographical error.
- Enhanced the clarity and professionalism of the README file.
