### PR TITLE
fix: update go-eth2-client to v0.26.0

### DIFF
--- a/cmd/node/events/process.go
+++ b/cmd/node/events/process.go
@@ -19,7 +19,8 @@ import (
 	"fmt"
 
 	eth2client "github.com/attestantio/go-eth2-client"
-	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/pkg/errors"
 )
 
@@ -28,7 +29,10 @@ func process(ctx context.Context, data *dataIn) error {
 		return errors.New("no data")
 	}
 
-	err := data.eth2Client.(eth2client.EventsProvider).Events(ctx, data.topics, eventHandler)
+	err := data.eth2Client.(eth2client.EventsProvider).Events(ctx, &api.EventsOpts{
+		Topics:  data.topics,
+		Handler: eventHandler,
+	})
 	if err != nil {
 		return errors.Wrap(err, "failed to connect for events")
 	}
@@ -38,7 +42,7 @@ func process(ctx context.Context, data *dataIn) error {
 	return nil
 }
 
-func eventHandler(event *api.Event) {
+func eventHandler(event *apiv1.Event) {
 	if event.Data == nil {
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.23.2
 
 require (
-	github.com/attestantio/go-eth2-client v0.24.1
+	github.com/attestantio/go-eth2-client v0.26.0
 	github.com/ferranbt/fastssz v0.1.4
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/attestantio/go-eth2-client v0.24.1 h1:DZ/2O83eUcSfPPs63xF6fdXDe4afA4nlt5j0y2cweOI=
-github.com/attestantio/go-eth2-client v0.24.1/go.mod h1:/KTLN3WuH1xrJL7ZZrpBoWM1xCCihnFbzequD5L+83o=
+github.com/attestantio/go-eth2-client v0.26.0 h1:oDWKvIUJfvr1EBi/w9L6mawYZHOCymjHkml7fZplT20=
+github.com/attestantio/go-eth2-client v0.26.0/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
Should resolve `failed to unmarshal data\njson: cannot unmarshal array into Go value of type string` when using Teku